### PR TITLE
fixing filename to long bug on encrypted directories

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,3 +17,5 @@ mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) => {
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 //testOptions in Test += Tests.Argument("-oF")
+
+scalacOptions ++= Seq("-Xmax-classfile-name", "140")


### PR DESCRIPTION
The scala compiler errors out when compiling scala projects on encrypted home directores, see this stackoverflow question for more info

https://stackoverflow.com/questions/28565837/filename-too-long-sbt